### PR TITLE
Add support for `$.param`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,31 @@ withDefaults({ _host: 'api.example.com' }, function(generate) {
 urls.userUrl(1);
 ```
 
+### Using a fancier query encoder
+
+By default, the query string is built using a simple function that calls
+`toString()` on param values and then URI-encodes the param keys and values.
+For some use cases, it's helpful to use alternate strategies for this -- for
+example, you might want to use jQuery's `$.param` to convert objects and arrays
+into Rails-style bracket notation. You can accomplish this by calling the
+function exported from the `url-sweatshirt` module and passing in a function
+with the appropriate signature (takes a single object param and returns a
+string).
+
+``` javascript
+var simpleGenerate = require('url-sweatshirt').generate;
+var simpleHomeUrl = simpleGenerate('/');
+
+var complexGenerate = require('url-sweatshirt')($.param).generate;
+var complexHomeUrl = complexGenerate('/');
+
+// returns '/?a=1&b=[object%20Object]'
+simpleHomeUrl({ a: 1, b: { c: 2, d: 3 }});
+
+// returns '/?a=1&b[c]=2&b[d]=3`
+complexHomeUrl({ a: 1, b: { c: 2, d: 3 }});
+```
+
 ### Features that aren't supported yet
 
 * Optional and splat params.

--- a/spec/generate_spec.js
+++ b/spec/generate_spec.js
@@ -136,4 +136,29 @@ describe('generate', () => {
       expect(categoryUrl({ name: null })).toEqual('/categories');
     });
   });
+
+  describe('with a custom query encoder', () => {
+    let generate, homeUrl;
+
+    function myCustomEncoder(obj) {
+      if (obj.returnHello) {
+        return 'hello';
+      } else {
+        return '';
+      }
+    }
+
+    beforeEach(() => {
+      generate = require('../index')(myCustomEncoder).generate;
+      homeUrl = generate('/');
+    });
+
+    it('uses the custom encoder', () => {
+      expect(homeUrl({ returnHello: true })).toEqual('/?hello');
+    });
+
+    it('omits the ? if the custom encoder returns an empty string', () => {
+      expect(homeUrl({ dontReturnHello: true })).toEqual('/');
+    });
+  });
 });

--- a/spec/with_defaults_spec.js
+++ b/spec/with_defaults_spec.js
@@ -40,4 +40,24 @@ describe('withDefaults', () => {
   it('can have the param removed by route-specific default params', () => {
     expect(relativeUrl()).toEqual('/local');
   });
+
+  describe('with a custom query encoder', () => {
+    let withDefaults;
+
+    function myCustomEncoder(obj) {
+      return 'hello';
+    }
+
+    beforeEach(() => {
+      withDefaults = require('../index')(myCustomEncoder).withDefaults;
+
+      withDefaults({ _host: 'api.example.com' }, function(generate) {
+        userUrl = generate('/');
+      });
+    });
+
+    it('uses the custom encoder', () => {
+      expect(userUrl()).toEqual('//api.example.com/?hello');
+    });
+  });
 });


### PR DESCRIPTION
In order to fully replace JsRoutes, our helpers need to be able to take
a complex object tree and serialize it into the query string of a
generated URL. This commit solves that problem by letting users pass in
any appropriate serialization function, including jQuery's `$.param`.